### PR TITLE
fix: Custom redirect selected by user not working

### DIFF
--- a/classes/ColdTrick/LoginRedirector/Login.php
+++ b/classes/ColdTrick/LoginRedirector/Login.php
@@ -98,7 +98,7 @@ class Login {
 					$url = 'dashboard';
 				}
 				break;
-			case 'custom':
+			case 'custom_redirect':
 				$custom = elgg_get_plugin_setting('custom_redirect', 'login_redirector');
 				if (!empty($custom)) {
 					$url = str_ireplace('[wwwroot]', elgg_get_site_url(), $custom);

--- a/views/default/plugins/login_redirector/settings.php
+++ b/views/default/plugins/login_redirector/settings.php
@@ -16,7 +16,7 @@ if (elgg_is_active_plugin('dashboard')) {
 if (elgg_is_active_plugin('profile')) {
 	$redirect_options['profile'] = elgg_echo('login_redirector:admin:option:profile');
 }
-$redirect_options['custom'] = elgg_echo('login_redirector:admin:option:custom_redirect');
+$redirect_options['custom_redirect'] = elgg_echo('login_redirector:admin:option:custom_redirect');
 
 $first_redirect_options = [
 	'none' => elgg_echo('login_redirector:admin:option:none'),


### PR DESCRIPTION
This fixes an issue where a user selected the custom redirect and was redirected to the route "custom_redirect" instead to the configured link.